### PR TITLE
Add output files to YAML header

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -4,6 +4,10 @@ output: html_document
 resource_files:
 - outputs/g_plot.pdf
 - outputs/t_table.html
+rmd_output_metadata:
+  rsc_output_files:
+    - "outputs/g_plot.pdf"
+    - "outputs/t_table.html"
 ---
 
 


### PR DESCRIPTION
Hi there, I'm kelly from RStudio. Your support question was escalated to me this afternoon. I think this is all you need to add to your index.Rmd to get Connect to link to your files. The trick is that you need to tell Connect about output files in addition to the resource files you already declared. 

Another way to do this would be to add them in a code chunk like this:
```
outputs <- list("outputs/g_plot.pdf", "outputs/t_table.html")
rmarkdown::output_metadata$set(rsc_output_files = outputs)
```
More details in the User Guide here: https://docs.rstudio.com/connect/user/rmarkdown/#r-markdown-output-files 
Hope this helps.